### PR TITLE
Fixed Bug

### DIFF
--- a/src/Migration.php
+++ b/src/Migration.php
@@ -120,8 +120,13 @@ class Migration extends BaseMigration
                     $privilege['_force'] ?? null
                 );
             } else {
+                if ($privilege['type'] === Item::TYPE_ROLE) {
+                    $methodName = 'getRole';
+                } else {
+                    $methodName = 'getPermission';
+                }
                 // use existing item
-                $current = Yii::$app->authManager->getRole($privilege['name']);
+                $current = Yii::$app->authManager->$methodName($privilege['name']);
                 if (!$current) {
                     throw new \yii\base\Exception("Item '{$privilege['name']}' not found");
                 }


### PR DESCRIPTION
Allow the _exits flag for Roles and Permissions

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | Currently the _exists flag only works with roles. With this fix it now works for both roles and permissions
